### PR TITLE
Create index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -28,6 +28,9 @@ declare namespace gulpUserscript {
     'run-at'?: 'document-start' | 'document-body' | 'document-end' | 'document-idle' | 'context-menu';
     grant?: string | string[];
     nocompat?: string;
+
+    // For others not listed
+    [key: string]: string | string[];
   }
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,36 @@
+import stream from 'stream';
+
+declare namespace gulpUserscript {
+  interface Header {
+    name: string;
+    namespace?: string;
+    version?: string;
+    author?: string;
+    description?: string;
+    homepage?: string;
+    homepageURL?: string;
+    website?: string;
+    source?: string;
+    icon?: string;
+    iconURL?: string;
+    defaulticon?: string;
+    icon64?: string;
+    icon64URL?: string;
+    updateURL?: string;
+    downloadURL?: string;
+    supportURL?: string;
+    include?: string | string[];
+    match?: string | string[];
+    exclude?: string | string[];
+    require?: string | string[];
+    resource?: string | string[];
+    connect?: string | string[];
+    'run-at'?: 'document-start' | 'document-body' | 'document-end' | 'document-idle' | 'context-menu';
+    grant?: string | string[];
+    nocompat?: string;
+  }
+}
+
+declare function gulpUserscript(opt: gulpUserscript.Header): stream.Transform;
+
+export = gulpUserscript;

--- a/package.json
+++ b/package.json
@@ -3,12 +3,14 @@
   "version": "1.1.0",
   "description": "Generate Userscript metadata with gulp.",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "lint": "eslint *.js",
     "test": "istanbul cover _mocha"
   },
   "files": [
-    "index.js"
+    "index.js",
+    "index.d.ts"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
Hi!
I'm using Gulp with TypeScript, but it's difficult to use because there is no `index.d.ts` typing file.
I think it would be good if you add `index.d.ts`.
Please review it for TypeScript users. :)

### Reference
* https://www.tampermonkey.net/documentation.php (Userscript Header)